### PR TITLE
Update seumasterthesis.cls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/main.tex
+++ b/main.tex
@@ -18,9 +18,9 @@
 %% ----------------------------------------------------------------------------
 \title
     {东南大学 \LaTeX 论文模板使用手册}        % 论文中文标题
-    {如何优雅地撰写硕士研究生毕业论文}         % 论文中文副标题，没有可以空着
+    {如何优雅地撰写硕士研究生毕业论文}         % 论文中文副标题，没有可以空着；如果标题过长，也可以用副标题实现换行
     {Southeast University \LaTeX ~Thesis Template User Manual}  % 论文英文标题
-    {How to Write a Master Thesis in an Elegant Way}            % 论文英文副标题，没有可以空着
+    {How to Write a Master Thesis in an Elegant Way}            % 论文英文副标题，没有可以空着；如果标题过长，也可以用副标题实现换行
 
 \spine
 	% 书脊标题与副标题

--- a/template/seumasterthesis.cls
+++ b/template/seumasterthesis.cls
@@ -794,7 +794,11 @@
                 \makebox[3.5cm][s]{\xiaoerhao\heiti\advisorpre:  } &
                 \underline {
                     \makebox[6cm][s] {
-                        \xiaoerhao\songti\textbf{\@advisorname}
+                        \hspace*{1.7cm}
+                        \makebox[2.5cm][c]{
+                            \xiaoerhao\songti\textbf{\@advisorname}
+                        }
+                        \makebox[2cm][r]{}
                     }
                 }
                 \\
@@ -802,7 +806,11 @@
                 \ifcoadvisor
                 \underline{
                     \makebox[6cm][s] {
-                        \xiaoerhao\songti\textbf{\@coadvisorname}
+                        \hspace*{1.7cm}
+                        \makebox[2.5cm][c]{
+                            \xiaoerhao\songti\textbf{\@coadvisorname}
+                        }
+                        \makebox[2cm][r]{}
                     }
                 }
                 \else

--- a/template/seumasterthesis.cls
+++ b/template/seumasterthesis.cls
@@ -495,7 +495,7 @@
         \begin{center}
             \linespread{1.25}
             \erhao\heiti\@title\\
-%            \erhao\heiti\@subtitle\\    % 修改3 -- Reanon 为了避免空副标题
+            \erhao\heiti\@subtitle\\
         \end{center}
     \end{minipage}
 
@@ -794,6 +794,7 @@
                 \makebox[3.5cm][s]{\xiaoerhao\heiti\advisorpre:  } &
                 \underline {
                     \makebox[6cm][s] {
+                        % ririv: 修正了双导师名字分别为两字和三字时名字不对齐问题
                         \hspace*{1.7cm}
                         \makebox[2.5cm][c]{
                             \xiaoerhao\songti\textbf{\@advisorname}
@@ -806,6 +807,7 @@
                 \ifcoadvisor
                 \underline{
                     \makebox[6cm][s] {
+                        % ririv: 修正了双导师名字分别为两字和三字时名字不对齐问题
                         \hspace*{1.7cm}
                         \makebox[2.5cm][c]{
                             \xiaoerhao\songti\textbf{\@coadvisorname}


### PR DESCRIPTION
修复Inner page中，双导师名字分别两字和三字时，在两字名字导师中间插入一中文空格后，双导师名字依旧不对齐问题。

main.tex中导师姓名样例
\advisor
    {李可欣~~教授}                % 导师中文姓名
    {LI Ke-Xin}        % 导师英文姓名
    {Prof.}                     % 导师职称
    
\coadvisor                % 联合培养导师姓名，没有可以不写
    {王\hspace{1em}东~~高工}          % 导师中文姓名
    {WANG Dong}             % 导师英文姓名
    {A.P.}     % 导师职称 (English), 如教授（Prof.）、副教授（A.P.）