### PR TITLE
优化参考文献、目录；统一序号标记

### DIFF
--- a/reference.bib
+++ b/reference.bib
@@ -78,3 +78,13 @@
   year={1998},
   school={Citeseer}
 }
+
+% arXiv文献参考格式
+@misc{liu2024coca,
+      title={COCA: Classifier-Oriented Calibration via Textual Prototype for Source-Free Universal Domain Adaptation}, 
+      author={Xinghong Liu and Yi Zhou and Tao Zhou and Chun-Mei Feng and Ling Shao},
+      year={2024},
+      eprint={2308.10450},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}

--- a/template/seumasterthesis.bst
+++ b/template/seumasterthesis.bst
@@ -1,67 +1,119 @@
-%%  This is file `gbt7714-unsrt.bst', generated with the docstrip utility.
-%% ----------------------------------------------------------------------------
-%%  GB/T 7714-2015 BibTeX Style
-%%  https://github.com/CTeX-org/gbt7714-bibtex-style
-%%  Version: 2019/11/20 v1.1.2
-%% ----------------------------------------------------------------------------
-%%  Copyright (C) 2016-2019 by Zeping Lee <zepinglee AT gmail.com>
-%%  Copyright (C) 2019 Rui Song <wurahara@163.com>
-%% ----------------------------------------------------------------------------
-%%  This file may be distributed and/or modified under the
-%%  conditions of the LaTeX Project Public License, either version 1.3c
-%%  of this license or (at your option) any later version.
-%% ----------------------------------------------------------------------------
-
-
+%%
+%% This is file `gbt7714-2005-numerical.bst',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% gbt7714.dtx  (with options: `2005,numerical')
+%% -------------------------------------------------------------------
+%% GB/T 7714 BibTeX Style
+%% https://github.com/zepinglee/gbt7714-bibtex-style
+%% Version: 2024/03/08 v2.1.6
+%% -------------------------------------------------------------------
+%% Copyright (C) 2016--2024 by Zeping Lee <zepinglee AT gmail.com>
+%% -------------------------------------------------------------------
+%% This file may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3c
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%%    https://www.latex-project.org/lppl.txt
+%% and version 1.3c or later is part of all distributions of LaTeX
+%% version 2008 or later.
+%% -------------------------------------------------------------------
 INTEGERS {
+  citation.et.al.min
+  citation.et.al.use.first
+  bibliography.et.al.min
+  bibliography.et.al.use.first
   uppercase.name
-  max.num.authors
-  period.between.author.year
+  terms.in.macro
+  year.after.author
+  period.after.author
+  italic.book.title
   sentence.case.title
   link.title
+  title.in.journal
+  show.patent.country
   show.mark
+  space.before.mark
   show.medium.type
-  slash.for.extraction
-  in.booktitle
-  italic.jounal
+  short.journal
+  italic.journal
+  link.journal
   bold.journal.volume
   show.missing.address.publisher
+  space.before.pages
+  only.start.page
+  wave.dash.in.pages
+  show.urldate
   show.url
   show.doi
+  show.preprint
   show.note
+  show.english.translation
+  end.with.period
+}
+
+STRINGS {
+  component.part.label
 }
 
 FUNCTION {load.config}
 {
+  #2 'citation.et.al.min :=
+  #1 'citation.et.al.use.first :=
+  #4 'bibliography.et.al.min :=
+  #3 'bibliography.et.al.use.first :=
   #1 'uppercase.name :=
-  #3 'max.num.authors :=
+  #0 'terms.in.macro :=
+  #0 'year.after.author :=
+  #1 'period.after.author :=
+  #0 'italic.book.title :=
   #1 'sentence.case.title :=
   #0 'link.title :=
+  #1 'title.in.journal :=
+  #1 'show.patent.country :=
   #1 'show.mark :=
+  #0 'space.before.mark :=
   #1 'show.medium.type :=
-  #1 'slash.for.extraction :=
-  #0 'in.booktitle :=
-  #0 'italic.jounal :=
+  "slash" 'component.part.label :=
+  #0 'short.journal :=
+  #0 'italic.journal :=
+  #0 'link.journal :=
   #0 'bold.journal.volume :=
-  #1 'show.missing.address.publisher :=
+  #0 'show.missing.address.publisher :=
+  #1 'space.before.pages :=
+  #0 'only.start.page :=
+  #0 'wave.dash.in.pages :=
+  #1 'show.urldate :=
   #1 'show.url :=
-  #1 'show.doi :=
+  #0 'show.doi :=
+  #1 'show.preprint :=
   #0 'show.note :=
+  #0 'show.english.translation :=
+  #1 'end.with.period :=
 }
 
 ENTRY
   { address
+    archivePrefix
     author
     booktitle
     date
     doi
     edition
     editor
+    eprint
+    eprinttype
+    entrysubtype
     howpublished
     institution
     journal
+    journaltitle
     key
+    langid
     language
+    location
     mark
     medium
     note
@@ -71,15 +123,17 @@ ENTRY
     publisher
     school
     series
+    shortjournal
     title
+    translation
     translator
     url
     urldate
     volume
     year
   }
-  { entry.lang entry.is.electronic entry.numbered }
-  { label extra.label sort.label short.list entry.mark entry.url }
+  { entry.lang entry.is.electronic is.pure.electronic entry.numbered }
+  { label extra.label sort.label short.label short.list entry.mark entry.url }
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block after.slash }
 
@@ -114,6 +168,9 @@ FUNCTION {bbl.space}
   if$
 }
 
+FUNCTION {bbl.and}
+{ "" }
+
 FUNCTION {bbl.et.al}
 { entry.lang lang.zh =
     { "等" }
@@ -129,12 +186,30 @@ FUNCTION {bbl.et.al}
   if$
 }
 
+FUNCTION {citation.and}
+{ terms.in.macro
+    { "{\biband}" }
+    'bbl.and
+  if$
+}
+
 FUNCTION {citation.et.al}
-{ bbl.et.al }
+{ terms.in.macro
+    { "{\bibetal}" }
+    'bbl.et.al
+  if$
+}
 
 FUNCTION {bbl.colon} { ": " }
 
-FUNCTION {bbl.wide.space} { "\quad " }
+FUNCTION {bbl.pages.colon}
+{ space.before.pages
+    { ": " }
+    { ":\allowbreak " }
+  if$
+}
+
+FUNCTION {bbl.wide.space} { "\ " }
 
 FUNCTION {bbl.slash} { "//\allowbreak " }
 
@@ -175,6 +250,22 @@ FUNCTION {or}
 {   { pop$ #1 }
     'skip$
   if$
+}
+
+STRINGS { x y }
+
+FUNCTION {contains}
+{ 'y :=
+  'x :=
+  y text.length$ 'len :=
+  x text.length$ len - #1 + 'charptr :=
+    { charptr #0 >
+      x charptr len substring$ y = not
+      and
+    }
+    { charptr #1 - 'charptr := }
+  while$
+  charptr #0 >
 }
 
 STRINGS { s t }
@@ -252,8 +343,17 @@ FUNCTION {output.check}
 }
 
 FUNCTION {fin.entry}
-{ add.period$
+{ end.with.period
+    'add.period$
+    'skip$
+  if$
   write$
+  show.english.translation entry.lang lang.zh = and
+    { ")"
+      write$
+    }
+    'skip$
+  if$
   newline$
 }
 
@@ -286,9 +386,22 @@ FUNCTION {new.sentence}
 FUNCTION {new.slash}
 { output.state before.all =
     'skip$
-    { slash.for.extraction
+    { component.part.label "slash" =
         { after.slash 'output.state := }
-        { after.block 'output.state := }
+        { new.block
+          component.part.label "in" =
+            { entry.lang lang.en =
+                { "In: " output
+                  write$
+                  ""
+                  before.all 'output.state :=
+                }
+                'skip$
+              if$
+            }
+            'skip$
+          if$
+        }
       if$
     }
   if$
@@ -333,10 +446,18 @@ FUNCTION {field.or.null}
   if$
 }
 
-FUNCTION {italicize}
+FUNCTION {emphasize}
 { duplicate$ empty$
     { pop$ "" }
-    { "\textit{" swap$ * "}" * }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+
+FUNCTION {format.btitle}
+{ italic.book.title
+  entry.lang lang.en = and
+    'emphasize
+    'skip$
   if$
 }
 
@@ -419,16 +540,27 @@ FUNCTION {check.entry.lang}
   get.str.lang
 }
 
+STRINGS { entry.langid }
+
 FUNCTION {set.entry.lang}
-{ language empty$
+{ "" 'entry.langid :=
+  language empty$ not
+    { language 'entry.langid := }
+    'skip$
+  if$
+  langid empty$ not
+    { langid 'entry.langid := }
+    'skip$
+  if$
+  entry.langid empty$
     { check.entry.lang }
-    { language "english" = language "american" = or language "british" = or
+    { entry.langid "english" = entry.langid "american" = or entry.langid "british" = or
         { lang.en }
-        { language "chinese" =
+        { entry.langid "chinese" =
             { lang.zh }
-            { language "japanese" =
+            { entry.langid "japanese" =
                 { lang.ja }
-                { language "russian" =
+                { entry.langid "russian" =
                     { lang.ru }
                     { check.entry.lang }
                   if$
@@ -454,37 +586,48 @@ FUNCTION {set.entry.numbered}
 
 INTEGERS { nameptr namesleft numnames name.lang }
 
+FUNCTION {format.name}
+{ "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
+  t "others" =
+    { bbl.et.al }
+    { t get.str.lang 'name.lang :=
+      name.lang lang.en =
+        { t #1 "{vv~}{ll}{ f{~}}" format.name$
+          uppercase.name
+            { "u" change.case$ }
+            'skip$
+          if$
+          t #1 "{, jj}" format.name$ *
+        }
+        { t #1 "{ll}{ff}" format.name$ }
+      if$
+    }
+  if$
+}
+
 FUNCTION {format.names}
 { 's :=
   #1 'nameptr :=
   s num.names$ 'numnames :=
+  ""
   numnames 'namesleft :=
     { namesleft #0 > }
-    { s nameptr "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
-      nameptr max.num.authors >
-        { bbl.et.al
+    { s nameptr format.name bbl.et.al =
+      numnames bibliography.et.al.min #1 - > nameptr bibliography.et.al.use.first > and or
+        { ", " *
+          bbl.et.al *
           #1 'namesleft :=
         }
-        { t "others" =
-            { bbl.et.al }
-            { t get.str.lang 'name.lang :=
-              name.lang lang.en =
-                { t #1 "{vv~}{ll}{~f{~}}" format.name$
-                  uppercase.name
-                    { "u" change.case$ }
-                    'skip$
-                  if$
-                  t #1 "{, jj}" format.name$ *
-                }
-                { t #1 "{ll}{ff}" format.name$ }
+        { nameptr #1 >
+            { namesleft #1 = bbl.and "" = not and
+                { bbl.and * }
+                { ", " * }
               if$
             }
+            'skip$
           if$
+          s nameptr format.name *
         }
-      if$
-      nameptr #1 >
-        { ", " swap$ * * }
-        'skip$
       if$
       nameptr #1 + 'nameptr :=
       namesleft #1 - 'namesleft :=
@@ -594,7 +737,7 @@ FUNCTION {editor.full}
 
 FUNCTION {make.full.names}
 { type$ "book" =
-  type$ "inbook" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.full
     { type$ "collection" =
@@ -612,17 +755,13 @@ FUNCTION {output.bibitem}
   "\bibitem[" write$
   label ")" *
   make.full.names duplicate$ short.list =
-     { pop$ }
-     { * }
-  if$
-  's :=
-  s text.length$ 'charptr :=
-    { charptr #0 > s charptr #1 substring$ "[" = not and }
-    { charptr #1 - 'charptr := }
-  while$
-  charptr #0 >
-    { "{" s * "}" * }
-    { s }
+    { pop$ }
+    { duplicate$ "]" contains
+        { "{" swap$ * "}" * }
+        'skip$
+      if$
+      *
+    }
   if$
   "]{" * write$
   cite$ write$
@@ -643,7 +782,7 @@ FUNCTION {add.link}
 { url empty$ not
     { "\href{" url * "}{" * swap$ * "}" * }
     { doi empty$ not
-        { "\href{http://dx.doi.org/" doi * "}{" * swap$ * "}" * }
+        { "\href{https://doi.org/" doi * "}{" * swap$ * "}" * }
         'skip$
       if$
     }
@@ -659,7 +798,25 @@ FUNCTION {format.title}
         'skip$
       if$
       entry.numbered number empty$ not and
-        { bbl.colon * number * }
+        { bbl.colon *
+          type$ "patent" = show.patent.country and
+            { address empty$ not
+                { address * ", " * }
+                { location empty$ not
+                    { location * ", " * }
+                    { entry.lang lang.zh =
+                        { "中国" * ", " * }
+                        'skip$
+                      if$
+                    }
+                  if$
+                }
+              if$
+            }
+            'skip$
+          if$
+          number *
+        }
         'skip$
       if$
       link.title
@@ -722,7 +879,7 @@ FUNCTION {format.volume}
     { volume is.number
         { entry.lang lang.zh =
             { "第 " volume * " 卷" * }
-            { "volume" volume tie.or.space.connect }
+            { "Vol." volume tie.or.space.connect }
           if$
         }
         { volume }
@@ -737,7 +894,7 @@ FUNCTION {format.number}
     { number is.number
         { entry.lang lang.zh =
             { "第 " number * " 册" * }
-            { "number" number tie.or.space.connect }
+            { "No." number tie.or.space.connect }
           if$
         }
         { number }
@@ -804,6 +961,7 @@ FUNCTION {format.series.vol.num.title}
     }
     { format.title.vol.num }
   if$
+  format.btitle
   link.title
     'add.link
     'skip$
@@ -835,20 +993,90 @@ FUNCTION {format.series.vol.num.booktitle}
     }
     { format.booktitle.vol.num }
   if$
-  in.booktitle
-    { duplicate$ empty$ not entry.lang lang.en = and
-        { "In: " swap$ * }
+  format.btitle
+}
+
+FUNCTION {remove.period}
+{ 't :=
+  "" 's :=
+    { t empty$ not }
+    { t #1 #1 substring$ 'tmp.str :=
+      tmp.str "." = not
+        { s tmp.str * 's := }
         'skip$
       if$
+      t #2 global.max$ substring$ 't :=
     }
+  while$
+  s
+}
+
+FUNCTION {abbreviate}
+{ remove.period
+  't :=
+  t "l" change.case$ 's :=
+  ""
+  s "physical review letters" =
+    { "Phys Rev Lett" }
     'skip$
+  if$
+  's :=
+  s empty$
+    { t }
+    { pop$ s }
+  if$
+}
+
+FUNCTION {get.journal.title}
+{ short.journal
+    { shortjournal empty$ not
+        { shortjournal }
+        { journal empty$ not
+            { journal abbreviate }
+            { journaltitle empty$ not
+                { journaltitle abbreviate }
+                { "" }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+    { journal empty$ not
+        { journal }
+        { journaltitle empty$ not
+            { journaltitle }
+            { shortjournal empty$ not
+                { shortjournal }
+                { "" }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {check.arxiv.preprint}
+{ #1 #5 substring$ purify$ "l" change.case$ "arxiv" =
+    { #1 }
+    { #0 }
   if$
 }
 
 FUNCTION {format.journal}
-{ journal
-  italic.jounal entry.lang lang.en = and
-    'italicize
+{ get.journal.title
+  duplicate$ empty$ not
+    { italic.journal entry.lang lang.en = and
+        'emphasize
+        'skip$
+      if$
+      link.journal
+        'add.link
+        'skip$
+      if$
+    }
     'skip$
   if$
 }
@@ -880,7 +1108,11 @@ FUNCTION {format.mark}
         'skip$
       if$
       'entry.mark :=
-      "\allowbreak[" entry.mark * "]" *
+      space.before.mark
+        { " " }
+        { "\allowbreak" }
+      if$
+      "[" * entry.mark * "]" *
     }
     { "" }
   if$
@@ -907,16 +1139,20 @@ FUNCTION {format.edition}
 { edition empty$
     { "" }
     { edition is.number
-        { entry.lang lang.zh =
-            { edition " 版" * }
-            { edition num.to.ordinal " ed." * }
+        { edition "1" = not
+            { entry.lang lang.zh =
+                { edition " 版" * }
+                { edition num.to.ordinal " ed." * }
+              if$
+            }
+            'skip$
           if$
         }
         { entry.lang lang.en =
             { edition change.sentence.case 's :=
               s "Revised" = s "Revised edition" = or
                 { "Rev. ed." }
-                { s " ed." *}
+                { s " ed." * }
               if$
             }
             { edition }
@@ -948,8 +1184,15 @@ FUNCTION {format.publisher}
 
 FUNCTION {format.address.publisher}
 { address empty$ not
-    { address
-      format.publisher empty$ not
+    { address }
+    { location empty$ not
+        { location }
+        { "" }
+      if$
+    }
+  if$
+  duplicate$ empty$ not
+    { format.publisher empty$ not
         { bbl.colon * format.publisher * }
         { entry.is.electronic not show.missing.address.publisher and
             { bbl.colon * bbl.sine.nomine * }
@@ -958,7 +1201,8 @@ FUNCTION {format.address.publisher}
         }
       if$
     }
-    { entry.is.electronic not show.missing.address.publisher and
+    { pop$
+      entry.is.electronic not show.missing.address.publisher and
         { format.publisher empty$ not
             { bbl.sine.loco bbl.colon * format.publisher * }
             { bbl.sine.loco.sine.nomine }
@@ -1014,24 +1258,79 @@ FUNCTION {extract.after.dash}
   if$
 }
 
-FUNCTION {contains.dash}
+FUNCTION {extract.before.slash}
 { duplicate$ empty$
-    { pop$ #0 }
+    { pop$ "" }
     { 's :=
-        { s empty$ not
-          s #1 #1 substring$ "-" = not
+      #1 'charptr :=
+      s text.length$ #1 + 'len :=
+        { charptr len <
+          s charptr #1 substring$ "/" = not
           and
         }
-        { s #2 global.max$ substring$ 's := }
+        { charptr #1 + 'charptr := }
       while$
-      s empty$ not
+      s #1 charptr #1 - substring$
+    }
+  if$
+}
+
+FUNCTION {extract.after.slash}
+{ duplicate$ empty$
+    { pop$ "" }
+    { 's :=
+      #1 'charptr :=
+      s text.length$ #1 + 'len :=
+        { charptr len <
+          s charptr #1 substring$ "-" = not
+          and
+          s charptr #1 substring$ "/" = not
+          and
+        }
+        { charptr #1 + 'charptr := }
+      while$
+        { charptr len <
+          s charptr #1 substring$ "-" =
+          s charptr #1 substring$ "/" =
+          or
+          and
+        }
+        { charptr #1 + 'charptr := }
+      while$
+      s charptr global.max$ substring$
     }
   if$
 }
 
 FUNCTION {format.year}
 { year empty$ not
-    { year extract.before.dash }
+    { year extract.before.slash extra.label * }
+    { date empty$ not
+        { date extract.before.dash extra.label * }
+        { entry.is.electronic not
+            { "empty year in " cite$ * warning$ }
+            'skip$
+          if$
+          urldate empty$ not
+            { "[" urldate extract.before.dash * extra.label * "]" * }
+            { "" }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.periodical.year}
+{ year empty$ not
+    { year extract.before.slash
+      "--" *
+      year extract.after.slash
+      duplicate$ empty$
+        'pop$
+        { * }
+      if$
+    }
     { date empty$ not
         { date extract.before.dash }
         { "empty year in " cite$ * warning$
@@ -1043,14 +1342,28 @@ FUNCTION {format.year}
       if$
     }
   if$
-  extra.label *
 }
 
 FUNCTION {format.date}
-{ type$ "patent" = type$ "newspaper" = or
-  date empty$ not and
-    { date }
-    { year }
+{ date empty$ not
+    { type$ "patent" = type$ "newspaper" = or
+        { date }
+        { entrysubtype empty$ not
+            { type$ "article" = entrysubtype "newspaper" = and
+                { date }
+                { format.year }
+              if$
+            }
+            { format.year }
+          if$
+        }
+      if$
+    }
+    { year empty$ not
+        { format.year }
+        { "" }
+      if$
+    }
   if$
 }
 
@@ -1062,7 +1375,9 @@ FUNCTION {format.editdate}
 }
 
 FUNCTION {format.urldate}
-{ urldate empty$ not entry.is.electronic and
+{ show.urldate show.url and entry.url empty$ not and
+  is.pure.electronic or
+  urldate empty$ not and
     { "\allowbreak[" urldate * "]" * }
     { "" }
   if$
@@ -1073,7 +1388,10 @@ FUNCTION {hyphenate}
   ""
     { t empty$ not }
     { t #1 #1 substring$ "-" =
-        { "-" *
+        { wave.dash.in.pages
+            { "～" * }
+            { "-" * }
+          if$
             { t #1 #1 substring$ "-" = }
             { t #2 global.max$ substring$ 't := }
           while$
@@ -1093,6 +1411,18 @@ FUNCTION {format.pages}
   if$
 }
 
+FUNCTION {format.extracted.pages}
+{ pages empty$
+    { "" }
+    { pages
+      only.start.page
+        'extract.before.dash
+        'hyphenate
+      if$
+    }
+  if$
+}
+
 FUNCTION {format.journal.volume}
 { volume empty$ not
     { bold.journal.volume
@@ -1106,7 +1436,7 @@ FUNCTION {format.journal.volume}
 
 FUNCTION {format.journal.number}
 { number empty$ not
-    { "\penalty0 (" number * ")" * }
+    { "\allowbreak (" number * ")" * }
     { "" }
   if$
 }
@@ -1114,13 +1444,13 @@ FUNCTION {format.journal.number}
 FUNCTION {format.journal.pages}
 { pages empty$
     { "" }
-    { ":\penalty0 " pages hyphenate * }
+    { format.extracted.pages }
   if$
 }
 
 FUNCTION {format.periodical.year.volume.number}
 { year empty$ not
-    { year extract.before.dash }
+    { year extract.before.slash }
     { "empty year in periodical " cite$ * warning$ }
   if$
   volume empty$ not
@@ -1128,27 +1458,23 @@ FUNCTION {format.periodical.year.volume.number}
     'skip$
   if$
   number empty$ not
-    { "\penalty0 (" * number extract.before.dash * ")" * }
+    { "\allowbreak (" * number extract.before.dash * ")" * }
     'skip$
   if$
-  year contains.dash
-    { "--" *
-      year extract.after.dash empty$
-      volume extract.after.dash empty$ and
-      number extract.after.dash empty$ and not
-        { year extract.after.dash empty$ not
-            { year extract.after.dash * }
-            { year extract.before.dash * }
-          if$
-          volume empty$ not
-            { ", " * volume extract.after.dash * }
-            'skip$
-          if$
-          number empty$ not
-            { "\penalty0 (" * number extract.after.dash * ")" * }
-            'skip$
-          if$
-        }
+  "--" *
+  year extract.after.slash empty$
+  volume extract.after.dash empty$ and
+  number extract.after.dash empty$ and not
+    { year extract.after.slash empty$ not
+        { year extract.after.slash * }
+        { year extract.before.slash * }
+      if$
+      volume empty$ not
+        { ", " * volume extract.after.dash * }
+        'skip$
+      if$
+      number empty$ not
+        { "\allowbreak (" * number extract.after.dash * ")" * }
         'skip$
       if$
     }
@@ -1185,10 +1511,13 @@ FUNCTION {check.url}
   if$
 }
 
-FUNCTION {format.url}
-{ entry.url empty$ not
-    { new.block entry.url }
-    { "" }
+FUNCTION {output.url}
+{ show.url is.pure.electronic or
+  entry.url empty$ not and
+    { new.block
+      entry.url output
+    }
+    'skip$
   if$
 }
 
@@ -1222,7 +1551,7 @@ FUNCTION {is.in.url}
 
 FUNCTION {format.doi}
 { ""
-  doi empty$ not show.doi and
+  doi empty$ not
     { "" 's :=
       doi 't :=
       #0 'numnames :=
@@ -1250,11 +1579,16 @@ FUNCTION {format.doi}
           t #2 global.max$ substring$ 't :=
         }
       while$
-      's :=
-      s empty$ not
-        { new.block s }
-        { "" }
-      if$
+    }
+    'skip$
+  if$
+}
+
+FUNCTION {output.doi}
+{ doi empty$ not show.doi and
+  show.english.translation entry.lang lang.zh = and not and
+    { new.block
+      format.doi output
     }
     'skip$
   if$
@@ -1279,10 +1613,66 @@ FUNCTION {check.electronic}
   if$
 }
 
+FUNCTION {format.eprint}
+{ archivePrefix empty$ not
+    { archivePrefix }
+    { eprinttype empty$ not
+        { archivePrefix }
+        { "" }
+      if$
+    }
+  if$
+  's :=
+  s empty$ not
+    { s ": \eprint{" *
+      url empty$ not
+        { url }
+        { "https://" s "l" change.case$ * ".org/abs/" * eprint * }
+      if$
+      * "}{" *
+      eprint * "}" *
+    }
+    { eprint }
+  if$
+}
+
+FUNCTION {output.eprint}
+{ show.preprint eprint empty$ not and
+    { new.block
+      format.eprint output
+    }
+    'skip$
+  if$
+}
+
 FUNCTION {format.note}
 { note empty$ not show.note and
     { note }
     { "" }
+  if$
+}
+
+FUNCTION {output.translation}
+{ show.english.translation entry.lang lang.zh = and
+    { translation empty$ not
+        { translation }
+        { "[English translation missing!]" }
+      if$
+      " (in Chinese)" * output
+      write$
+      format.doi duplicate$ empty$ not
+        { newline$
+          write$
+        }
+        'pop$
+      if$
+      " \\" write$
+      newline$
+      "(" write$
+      ""
+      before.all 'output.state :=
+    }
+    'skip$
   if$
 }
 
@@ -1298,6 +1688,7 @@ FUNCTION {empty.misc.check}
 
 FUNCTION {monograph}
 { output.bibitem
+  output.translation
   author empty$ not
     { format.authors }
     { editor empty$ not
@@ -1309,6 +1700,15 @@ FUNCTION {monograph}
     }
   if$
   output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
   format.series.vol.num.title "title" output.check
   "M" set.entry.mark
@@ -1318,12 +1718,15 @@ FUNCTION {monograph}
   new.sentence
   format.edition output
   new.block
-  format.publisher output
-  format.year "year" output.check
-  format.pages ". " output.after
+  format.address.publisher output
+  year.after.author not
+    { format.year "year" output.check }
+    'skip$
+  if$
+  format.pages bbl.pages.colon output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1331,27 +1734,40 @@ FUNCTION {monograph}
 
 FUNCTION {incollection}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
   format.title "title" output.check
   "M" set.entry.mark
   format.mark "" output.after
   new.block
   format.translators output
-  new.block
+  new.slash
   format.editors output
   new.block
   format.series.vol.num.booktitle "booktitle" output.check
   new.block
   format.edition output
   new.block
-  format.publisher output
-  format.year "year" output.check
-  format.pages ". " output.after
+  format.address.publisher output
+  year.after.author not
+    { format.year "year" output.check }
+    'skip$
+  if$
+  format.extracted.pages bbl.pages.colon output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1359,8 +1775,18 @@ FUNCTION {incollection}
 
 FUNCTION {periodical}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
   format.title "title" output.check
   "J" set.entry.mark
@@ -1369,32 +1795,60 @@ FUNCTION {periodical}
   format.periodical.year.volume.number output
   new.block
   format.address.publisher output
-  format.date "year" output.check
+  year.after.author not
+    { format.periodical.year "year" output.check }
+    'skip$
+  if$
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
 }
 
-FUNCTION {article}
+FUNCTION {journal.article}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
-  format.title "title" output.check
-  "J" set.entry.mark
-  format.mark "" output.after
-  new.block
+  title.in.journal
+    { format.title "title" output.check
+      entrysubtype empty$ not
+        {
+          entrysubtype "newspaper" =
+            { "N" set.entry.mark }
+            { "J" set.entry.mark }
+          if$
+        }
+        { "J" set.entry.mark }
+      if$
+      format.mark "" output.after
+      new.block
+    }
+    'skip$
+  if$
   format.journal "journal" output.check
-  format.date "year" output.check
+  year.after.author not
+    { format.date "year" output.check }
+    'skip$
+  if$
   format.journal.volume output
   format.journal.number "" output.after
-  format.journal.pages "" output.after
+  format.journal.pages bbl.pages.colon output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1402,8 +1856,18 @@ FUNCTION {article}
 
 FUNCTION {patent}
 { output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
   format.title "title" output.check
   "P" set.entry.mark
@@ -1411,8 +1875,8 @@ FUNCTION {patent}
   new.block
   format.date "year" output.check
   format.urldate "" output.after
-  format.url output
-  format.doi output
+  output.url
+  output.doi
   new.block
   format.note output
   fin.entry
@@ -1421,22 +1885,95 @@ FUNCTION {patent}
 FUNCTION {electronic}
 { #1 #1 check.electronic
   #1 'entry.is.electronic :=
+  #1 'is.pure.electronic :=
   output.bibitem
+  output.translation
   format.authors output
   author format.key output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
   new.block
   format.series.vol.num.title "title" output.check
   "EB" set.entry.mark
   format.mark "" output.after
   new.block
   format.address.publisher output
-  format.pages bbl.colon output.after
+  year.after.author not
+    { date empty$
+        { format.date output }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+  format.pages bbl.pages.colon output.after
   format.editdate "" output.after
   format.urldate "" output.after
-  format.url output
-  format.doi output
-  date empty$
-    { format.date output }
+  output.url
+  output.doi
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {preprint}
+{ output.bibitem
+  output.translation
+  author empty$ not
+    { format.authors }
+    { editor empty$ not
+        { format.editors }
+        { "empty author and editor in " cite$ * warning$
+          ""
+        }
+      if$
+    }
+  if$
+  output
+  year.after.author
+    { period.after.author
+        'new.sentence
+        'skip$
+      if$
+      format.year "year" output.check
+    }
+    'skip$
+  if$
+  new.block
+  title.in.journal
+    { format.series.vol.num.title "title" output.check
+      "Z" set.entry.mark
+      format.mark "" output.after
+      new.block
+    }
+    'skip$
+  if$
+  format.translators output
+  new.sentence
+  format.edition output
+  new.block
+  year.after.author not
+    { date empty$
+        { format.date output }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+  format.pages bbl.pages.colon output.after
+  format.editdate "" output.after
+  format.urldate "" output.after
+  output.eprint
+  output.url
+  show.preprint not eprint empty$ or
+    'output.doi
     'skip$
   if$
   new.block
@@ -1445,16 +1982,27 @@ FUNCTION {electronic}
 }
 
 FUNCTION {misc}
-{ journal empty$ not
-    'article
-    { booktitle empty$ not
+{ get.journal.title
+  duplicate$ empty$ not
+    { check.arxiv.preprint
+        'preprint
+        'journal.article
+      if$
+    }
+    { pop$
+      booktitle empty$ not
         'incollection
         { publisher empty$ not
             'monograph
-            { entry.is.electronic
-                'electronic
-                { "Z" set.entry.mark
-                  monograph
+            { eprint empty$ not archivePrefix empty$ not or
+                'preprint
+                { entry.is.electronic
+                    'electronic
+                    {
+                      "M" set.entry.mark
+                      monograph
+                    }
+                  if$
                 }
               if$
             }
@@ -1470,6 +2018,8 @@ FUNCTION {archive}
 { "A" set.entry.mark
   misc
 }
+
+FUNCTION {article} { misc }
 
 FUNCTION {book} { monograph }
 
@@ -1490,7 +2040,12 @@ FUNCTION {dataset}
   electronic
 }
 
-FUNCTION {inbook} { book }
+FUNCTION {inbook} {
+  booktitle empty$
+    'book
+    'incollection
+  if$
+}
 
 FUNCTION {inproceedings}
 { "C" set.entry.mark
@@ -1498,6 +2053,8 @@ FUNCTION {inproceedings}
 }
 
 FUNCTION {conference} { inproceedings }
+
+FUNCTION {legislation} { archive }
 
 FUNCTION {map}
 { "CM" set.entry.mark
@@ -1543,10 +2100,7 @@ FUNCTION {techreport}
   misc
 }
 
-FUNCTION {unpublished}
-{ "Z" set.entry.mark
-  misc
-}
+FUNCTION {unpublished} { misc }
 
 FUNCTION {default.type} { misc }
 
@@ -1629,18 +2183,48 @@ FUNCTION {chop.word}
   if$
 }
 
+FUNCTION {format.lab.name}
+{ "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
+  t "others" =
+    { citation.et.al }
+    { t get.str.lang 'name.lang :=
+      name.lang lang.zh = name.lang lang.ja = or
+        { t #1 "{ll}{ff}" format.name$ }
+        { t #1 "{vv~}{ll}" format.name$ }
+      if$
+    }
+  if$
+}
+
 FUNCTION {format.lab.names}
 { 's :=
-  s #1 "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
-  t get.str.lang 'name.lang :=
-  name.lang lang.en =
-    { t #1 "{vv~}{ll}" format.name$}
-    { t #1 "{ll}{ff}" format.name$}
-  if$
-  s num.names$ #1 >
-    { bbl.space * citation.et.al * }
-    'skip$
-  if$
+  s #1 format.lab.name 'short.label :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  ""
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr format.lab.name citation.et.al =
+      numnames citation.et.al.min #1 - > nameptr citation.et.al.use.first > and or
+        { bbl.space *
+          citation.et.al *
+          #1 'namesleft :=
+        }
+        { nameptr #1 >
+            { namesleft #1 = citation.and "" = not and
+                { citation.and * }
+                { ", " * }
+              if$
+            }
+            'skip$
+          if$
+          s nameptr format.lab.name *
+        }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
 }
 
 FUNCTION {author.key.label}
@@ -1700,8 +2284,9 @@ FUNCTION {editor.key.organization.label}
 }
 
 FUNCTION {calc.short.authors}
-{ type$ "book" =
-  type$ "inbook" =
+{ "" 'short.label :=
+  type$ "book" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.key.label
     { type$ "collection" =
@@ -1717,11 +2302,32 @@ FUNCTION {calc.short.authors}
     }
   if$
   'short.list :=
+  short.label empty$
+    { short.list 'short.label := }
+    'skip$
+  if$
 }
 
 FUNCTION {calc.label}
 { calc.short.authors
-  short.list
+  short.list "]" contains
+    { "{" short.list * "}" * }
+    { short.list }
+  if$
+  "("
+  *
+  format.year duplicate$ empty$
+  short.list key field.or.null = or
+     { pop$ "" }
+     'skip$
+  if$
+  duplicate$ "]" contains
+    { "{" swap$ * "}" * }
+    'skip$
+  if$
+  *
+  'label :=
+  short.label
   "("
   *
   format.year duplicate$ empty$
@@ -1730,7 +2336,7 @@ FUNCTION {calc.label}
      'skip$
   if$
   *
-  'label :=
+  'short.label :=
 }
 
 INTEGERS { seq.num }
@@ -1747,6 +2353,7 @@ FUNCTION {presort}
 { set.entry.lang
   set.entry.numbered
   show.url show.doi check.electronic
+  #0 'is.pure.electronic :=
   calc.label
   label sortify
   "    "
@@ -1759,44 +2366,26 @@ FUNCTION {presort}
   'sort.key$ :=
 }
 
-STRINGS { longest.label last.label next.extra }
+STRINGS { longest.label last.label next.extra last.extra.label }
 
-INTEGERS { longest.label.width last.extra.num number.label }
+INTEGERS { longest.label.width number.label }
 
 FUNCTION {initialize.longest.label}
 { "" 'longest.label :=
   #0 int.to.chr$ 'last.label :=
   "" 'next.extra :=
   #0 'longest.label.width :=
-  #0 'last.extra.num :=
   #0 'number.label :=
+  "" 'last.extra.label :=
 }
 
 FUNCTION {forward.pass}
-{ last.label label =
-    { last.extra.num #1 + 'last.extra.num :=
-      last.extra.num int.to.chr$ 'extra.label :=
-    }
-    { "a" chr.to.int$ 'last.extra.num :=
-      "" 'extra.label :=
-      label 'last.label :=
-    }
-  if$
+{
   number.label #1 + 'number.label :=
 }
 
 FUNCTION {reverse.pass}
-{ next.extra "b" =
-    { "a" 'extra.label := }
-    'skip$
-  if$
-  extra.label 'next.extra :=
-  extra.label
-  duplicate$ empty$
-    'skip$
-    { "{\natexlab{" swap$ * "}}" * }
-  if$
-  'extra.label :=
+{
   label extra.label * 'label :=
 }
 
@@ -1811,23 +2400,37 @@ FUNCTION {begin.bib}
   if$
   "\begin{thebibliography}{" number.label int.to.str$ * "}" *
   write$ newline$
-  "\providecommand{\natexlab}[1]{#1}"
-  write$ newline$
-  "\providecommand{\url}[1]{#1}"
-  write$ newline$
-  "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
-  write$ newline$
-  "  \urlstyle{same}\fi"
-  write$ newline$
-  show.doi
-    { "\providecommand{\href}[2]{\url{#2}}"
+  terms.in.macro
+    { "\providecommand{\biband}{和}"
       write$ newline$
-      "\providecommand{\doi}[1]{\href{https://doi.org/#1}{#1}}"
+      "\providecommand{\bibetal}{等}"
       write$ newline$
     }
     'skip$
   if$
-}
+  "\providecommand{\natexlab}[1]{#1}"
+  write$ newline$
+  "\providecommand{\url}[1]{#1}"
+  write$ newline$
+  "\expandafter\ifx\csname urlstyle\endcsname\relax\else"
+  write$ newline$
+  "  \urlstyle{same}\fi"
+  write$ newline$
+  "\expandafter\ifx\csname href\endcsname\relax"
+  write$ newline$
+  "  \DeclareUrlCommand\doi{\urlstyle{rm}}"
+  write$ newline$
+  "  \def\eprint#1#2{#2}"
+      write$ newline$
+  "\else"
+  write$ newline$
+  "  \def\doi#1{\href{https://doi.org/#1}{\nolinkurl{#1}}}"
+  write$ newline$
+  "  \let\eprint\href"
+      write$ newline$
+  "\fi"
+      write$ newline$
+    }
 
 FUNCTION {end.bib}
 { newline$

--- a/template/seumasterthesis.cls
+++ b/template/seumasterthesis.cls
@@ -133,10 +133,20 @@
 \RequirePackage{algorithmicx}
 \RequirePackage{algpseudocode}
 \numberwithin{algorithm}{chapter}
+\renewcommand{\thealgorithm}{\thechapter{}-\arabic{algorithm}} % 修改5 -- 统一图、表、算法序号标记
 \renewcommand{\algorithmicrequire}{\textbf{输入:}}
 \renewcommand{\algorithmicensure}{\textbf{输出:}}
 \floatname{algorithm}{算法}
 \renewcommand{\listalgorithmname}{算法目录}
+% 修改6 -- 优化图、表、算法目录
+\let\oldlistofalgorithms\listofalgorithms
+\let\oldnumberline\numberline% Store \numberline
+\newcommand{\algnumberline}[1]{算法~#1}
+\renewcommand{\listofalgorithms}{%
+  \let\numberline\algnumberline% Update \numberline
+  \oldlistofalgorithms
+  \let\numberline\oldnumberline% Restore \numberline
+}
 
 %% ----------------------------------------------------------------------------
 %%                        Reference and Citation
@@ -176,8 +186,8 @@
 %%                          Table & Figure Settings
 %% ----------------------------------------------------------------------------
 
-\renewcommand{\thetable}{\thechapter{}.\arabic{table}}
-\renewcommand{\thefigure}{\thechapter{}-\arabic{figure}}
+\renewcommand{\thetable}{\thechapter{}-\arabic{table}} % 修改5 -- 统一图、表、算法序号标记
+\renewcommand{\thefigure}{\thechapter{}-\arabic{figure}} 
 \captionsetup[table]{labelsep=space}
 \captionsetup[figure]{labelsep=space}
 \RequirePackage{graphicx}
@@ -934,6 +944,16 @@
 %% ----------------------------------------------------------------------------
 %%                            Summary list
 %% ----------------------------------------------------------------------------
+
+% 修改6 -- 优化图、表、算法目录
+\renewcommand{\cftfigpresnum}{图\ }
+\renewcommand{\cfttabpresnum}{表\ }
+\newlength{\mylenf}
+\settowidth{\mylenf}{\cftfigpresnum}
+\setlength{\cftfignumwidth}{\dimexpr\mylenf+2.5em}
+\newlength{\mylent}
+\settowidth{\mylent}{\cfttabpresnum}
+\setlength{\cfttabnumwidth}{\dimexpr\mylent+2.5em}
 
 \newcommand\listofothers {
 


### PR DESCRIPTION
### 更新`seumasterthesis.bst`
1. 旧版`seumasterthesis.bst`无法在“参考文献”小节中正确显示arXiv文献。原作者Zeping Lee于2024/03/08更新了新版的参考文献模板文件。在新版本中增添了对于arXiv文献的支持。

旧版`seumasterthesis.bst`显示的arXiv文献：
<img width="284" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/092f7583-b029-4bc6-96c2-158252e9f894">

新版`seumasterthesis.bst`显示的arXiv文献：
<img width="287" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/1cda2a42-f216-4812-af9c-55222af8fb3f">


2. 旧版`seumasterthesis.bst`显示的会议文献格式有误，错误格式为"the title of paper[C]. the conference name"，正确格式应该为"the title of paper[C]//the conference name"。

旧版`seumasterthesis.bst`显示的会议文献：
<img width="672" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/d4e0681b-b0a4-4e54-ae0e-7451f6327009">

新版`seumasterthesis.bst`显示的会议文献：
<img width="693" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/95a957d7-9d06-4175-9dd9-b17df0110233">


### 更新`reference.bib`
增添arXiv文献参考格式
<img width="805" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/fada99be-888f-4787-89d8-fb6162b190ae">


### 更新`seumasterthesis.cls`
1. 优化图、表、算法目录的展示。
<img width="295" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/2e6213a6-a9b4-44b4-934f-d35f04d89396">


2. 图、表目录中序号和caption留出较大间隙，以实现多张图表序号和caption在目录中的对齐。例如下图中的1-9和1-10。
<img width="629" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/6e54196d-564a-4d6d-b2a2-243389e904f6">


3. 将图、表、算法的序号标记统一为“章节-章节内序号”的形式。例如之前为"图1-1"、“表1.1”。新版本中均统一为"图1-1"、“表1-1”、“算法1-1”。公式仍使用"(1.1)“的形式，以便审稿人区分“公式”和“算法”。
<img width="612" alt="image" src="https://github.com/Reanon/SEUThesisLatexTemplate/assets/39007456/7dfdbd43-1a99-432c-9645-4ac2446d6488">

